### PR TITLE
automount-actions: improve cleanup logic

### DIFF
--- a/automount-actions/scripts/bin/auto-install.sh
+++ b/automount-actions/scripts/bin/auto-install.sh
@@ -208,9 +208,6 @@ process_mounts() {
 cleanup() {
     _exit_status=$?
 
-    [ -z "${CLEANUP_HAS_RUN:-}" ] || return 0
-    CLEANUP_HAS_RUN=1
-
     rm -f "$WATCH_FILE"
 
     # Exit with 0 if we're interrupted with INT or TERM
@@ -225,7 +222,8 @@ main() {
     : "${WATCH_FILE:=/tmp/mounts.fifo}"; readonly WATCH_FILE
     [ -p "$WATCH_FILE" ] || mkfifo "$WATCH_FILE"
 
-    trap cleanup EXIT INT TERM
+    trap exit    INT TERM
+    trap cleanup EXIT
 
     process_mounts "$WATCH_FILE"
 }

--- a/automount-actions/scripts/bin/auto-mount.sh
+++ b/automount-actions/scripts/bin/auto-mount.sh
@@ -60,9 +60,6 @@ try_mount() {
 cleanup () {
     _exit_status=$?
 
-    [ -z "${CLEANUP_HAS_RUN:-}" ] || return 0
-    CLEANUP_HAS_RUN=1
-
     sync
 
     # TODO: parsing ls is potentially unreliable. find is an alternative but the
@@ -92,7 +89,8 @@ main() {
     : "${WATCH_FILE:=/tmp/mounts.fifo}"; readonly WATCH_FILE
     : "${MOUNT_DIR:="$(mktemp -d)"}";    readonly MOUNT_DIR
 
-    trap cleanup EXIT INT TERM
+    trap exit    INT TERM
+    trap cleanup EXIT
 
     watch_devices
 }


### PR DESCRIPTION
## Pull Request introduction

- [x] I have signed the [Canonical contributor license agreement](https://ubuntu.com/legal/contributors)
- [x] I have followed the [Style Guide](/README.md#Contributing)


## Pull Request description

Trap INT and TERM signals to `exit`, so that `cleanup()` is only called once. Remove logic that tracks how many times `cleanup()` has been called.


## Pull Request elaboration

- [x] I have documented any new functions or features either in code or in the
  example's README
- [x] I have added relevant tests or marked `TODO`s for what successful tests
  look like
