### PR TITLE
basic-server: add simple server example

### DIFF
--- a/.github/workflows/snap-build.yaml
+++ b/.github/workflows/snap-build.yaml
@@ -136,3 +136,23 @@ jobs:
         with:
           name: using-docker-snap
           path: ${{ steps.build-snap.outputs.snap }}
+  build_basic_server:
+    name: Build job for basic-server snap
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Test build of basic-server snap
+        uses: snapcore/action-build@v1
+        with:
+          path: basic-server/
+          build-info: true
+          snapcraft-channel: latest/edge
+        id: build-snap
+      - run: |
+          sudo snap install --dangerous ${{ steps.build-snap.outputs.snap }}
+      - name: Upload Snap Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: basic-server-snap
+          path: ${{ steps.build-snap.outputs.snap }}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ assertions on a device. The snaps and assertions are provided by a block device
 (e.g. a USB stick). This device is automatically mounted and checked for the
 correct files, and those files are then processed using the snapd REST API.
 
+### basic-server
+
+basic-server provides a simple configurable server example that utilizes many
+of the features available for snaps. By default, it echos "Hello, world!" to
+port 9999 on localhost.
+
 ### daemon-control
 
 daemon-control is a demonstration of how to orchestrate daemon startup between

--- a/basic-server/snap/hooks/configure
+++ b/basic-server/snap/hooks/configure
@@ -1,0 +1,7 @@
+#!/bin/sh -eu
+
+if [ -z "$(snapctl get daemon.port)" ]; then
+  snapctl set daemon.port=9999
+fi
+
+snapctl restart "${SNAP_INSTANCE_NAME}.daemon"

--- a/basic-server/snap/snapcraft.yaml
+++ b/basic-server/snap/snapcraft.yaml
@@ -1,0 +1,33 @@
+name: basic-server
+base: core22
+version: '0.1'
+summary: Simple server that greets clients
+description: |
+  basic-server is a simple server that listens on its configured port, sends
+  "Hello, world!", and disconnects from the client.
+
+grade: stable
+confinement: strict
+
+apps:
+  daemon:
+    command: usr/bin/server.sh
+    daemon: simple
+    install-mode: enable
+    plugs:
+      - network-bind
+
+parts:
+  src:
+    plugin: dump
+    source: ./src
+    organize:
+      server.sh: usr/bin/server.sh
+
+  ncat:
+    plugin: nil
+    stage-packages:
+      - ncat
+    stage:
+      - -usr/share
+      - -usr/lib/${CRAFT_ARCH_TRIPLET}/liblua5.3-c++*

--- a/basic-server/src/server.sh
+++ b/basic-server/src/server.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -eu
+
+PORT="$(snapctl get daemon.port)"
+
+while true; do
+  echo 'Hello, world!' | ncat --listen --send-only localhost "$PORT"
+done


### PR DESCRIPTION
## Pull Request introduction

- [x] I have signed the [Canonical contributor license agreement](https://ubuntu.com/legal/contributors)
- [x] I have followed the [Style Guide](/README.md#Contributing)


## Pull Request description

This PR adds an instructional snap that provides a basic `ncat`-based server daemon. It uses as many snap features as reasonably possible (each feature is used purposefully, not *just* to show off the feature), while also aiming to be as minimal and correct as possible.
