### PR TITLE
All IoT example snaps are on base snap core22

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 ## Overview
 
 This repository contains a collection of snaps created by the Devices Field
-team. They are not generally recommended for production but instead act as
-proof-of-concept examples for accomplishing particular tasks.
+team. All snaps in this branch are on base snap core22. They are not generally 
+recommended for production but instead act as proof-of-concept examples for 
+accomplishing particular tasks.
 
 Each subdirectory is a different example, each with their own accompanying
 READMEs which explain what they do, how they function, build instructions, and

--- a/automount-actions/README.md
+++ b/automount-actions/README.md
@@ -5,6 +5,8 @@ _Canonical Devices and IoT, Field Engineering_
 
 Version: 1.3
 
+Base Snap: core22 (Ubuntu 22.04)
+
 
 ## Introduction
 

--- a/daemon-control/README.md
+++ b/daemon-control/README.md
@@ -5,6 +5,8 @@ _Canonical Devices and IoT, Field Engineering_
 
 Version 1.3
 
+Base Snap: core22 (Ubuntu 22.04)
+
 ## Introduction
 
 This document presents an approach through which one snap can control startup of

--- a/daemon-control/controlled-daemon/snap/snapcraft.yaml
+++ b/daemon-control/controlled-daemon/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: test-controlled-daemons
-base: core18
+base: core22
 version: '1'
 summary: test a controlled daemon
 description: a controlled daemon

--- a/daemon-control/controller-daemon/snap/snapcraft.yaml
+++ b/daemon-control/controller-daemon/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: test-controller-daemons
-base: core18
+base: core22
 version: '1'
 summary: test a daemon controller
 description: a daemon controller
@@ -36,5 +36,9 @@ parts:
   snapdapi:
     source: .
     plugin: go
-    go-importpath: github.com/knitzsche/test-controller-daemons
-    build-packages: [ gcc ]
+    build-snaps: [go]
+    build-packages: [ gcc, git ]
+    override-build: |
+      go mod init github.com/knitzsche/test-controller-daemons
+      go mod tidy
+      craftctl default

--- a/daemon-control/controller-daemon/snapdapi/client.go
+++ b/daemon-control/controller-daemon/snapdapi/client.go
@@ -45,7 +45,7 @@ func (a *ClientAdapter) Snap(name string) (*client.Snap, *client.ResultInfo, err
 
 // 
 func (a *ClientAdapter) Start(names []string, opts client.StartOptions) (changeID string, err error) {
-	return a.snapdClient.Start(names, opts)
+	return a.snapdClient.Start(names, client.ScopeSelector{}, client.UserSelector{},  opts)
 }
 // List returns the list of all snaps installed on the system
 // with names in the given list; if the list is empty, all snaps.

--- a/one-codebase-many-snaps/snaps/snap-a/snap/snapcraft.yaml
+++ b/one-codebase-many-snaps/snaps/snap-a/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: snap-a # you probably want to 'snapcraft register <name>'
-base: core20 # the base snap is the execution environment for this snap
+base: core22 # the base snap is the execution environment for this snap
 version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
 summary: Single-line elevator pitch for your amazing snap # 79 char long summary
 description: |

--- a/one-codebase-many-snaps/snaps/snap-b/snap/snapcraft.yaml
+++ b/one-codebase-many-snaps/snaps/snap-b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: snap-b # you probably want to 'snapcraft register <name>'
-base: core20 # the base snap is the execution environment for this snap
+base: core22 # the base snap is the execution environment for this snap
 version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
 summary: Single-line elevator pitch for your amazing snap # 79 char long summary
 description: |

--- a/qt-imx/README.md
+++ b/qt-imx/README.md
@@ -2,6 +2,8 @@
 
 ***Notice**: This is an example and should not be used in production.*
 
+Base Snap: core22 (Ubuntu 22.04)
+
 ## Overview
 
 Qt application libraries compiled with support for the eglfs backend on i.MX 6 & 8 SoCs for use on Ubuntu Core 20.

--- a/qt-imx/patches/0001-Added-linux-imx8-g.patch
+++ b/qt-imx/patches/0001-Added-linux-imx8-g.patch
@@ -4,9 +4,9 @@ Date: Tue, 15 Mar 2022 18:13:45 +0000
 Subject: [PATCH 1/1] Added linux-imx8-g++
 
 ---
- qtbase/mkspecs/devices/linux-imx8-g++/qmake.conf     | 21 ++++++++++++
+ qtbase/mkspecs/devices/linux-imx8-g++/qmake.conf     | 27 ++++++++++++
  .../devices/linux-imx8-g++/qplatformdefs.h    | 34 +++++++++++++++++++
- 2 files changed, 55 insertions(+)
+ 2 files changed, 61 insertions(+)
  create mode 100644 qtbase/mkspecs/devices/linux-imx8-g++/qmake.conf
  create mode 100644 qtbase/mkspecs/devices/linux-imx8-g++/qplatformdefs.h
 
@@ -15,13 +15,19 @@ new file mode 100644
 index 0000000000..979dceea21
 --- /dev/null
 +++ b/qtbase/mkspecs/devices/linux-imx8-g++/qmake.conf
-@@ -0,0 +1,21 @@
+@@ -0,0 +1,27 @@
 +#
 +# qmake configuration for the Freescale iMX8 boards
 +#
 +# Derived from linux-imx6-g++
 +
 +include(../common/linux_device_pre.conf)
++
++# OpenGL ES 2.0 and EGL include/library paths
++QMAKE_INCDIR_EGL        = $$[QT_SYSROOT]/usr/include
++QMAKE_LIBDIR_EGL        = $$[QT_SYSROOT]/usr/lib/aarch64-linux-gnu
++QMAKE_INCDIR_OPENGL_ES2 = $$[QT_SYSROOT]/usr/include
++QMAKE_LIBDIR_OPENGL_ES2 = $$[QT_SYSROOT]/usr/lib/aarch64-linux-gnu
 +
 +QMAKE_LIBS_EGL          = -lEGL
 +QMAKE_LIBS_OPENGL_ES2   = -lGLESv2 -lEGL -lGAL

--- a/qt-imx/snap/snapcraft.yaml
+++ b/qt-imx/snap/snapcraft.yaml
@@ -19,9 +19,8 @@ description: |
 grade: devel
 confinement: devmode
 
-platforms:
-  arm64:
-    build-on: [amd64]
+architectures:
+  - build-on: [amd64]
     build-for: [arm64]
 
 plugs:
@@ -162,9 +161,9 @@ parts:
       unset PKG_CONFIG_PATH
 
       ./configure -debug -nomake tests -nomake examples -opensource -confirm-license \
-        -prefix /usr -sysroot ${CRAFT_PROJECT_DIR}/stage \
-        -opengl es2 -no-pulseaudio -qpa eglfs -qt-xcb -qt-pcre \
-        -qt-libjpeg -qt-libpng -qt-freetype -qt-zlib -qt-xkbcommon-x11 \
+        -prefix /usr -sysroot ${CRAFT_STAGE} \
+        -opengl es2 -no-pulseaudio -qpa eglfs -no-xcb -qt-pcre \
+        -qt-libjpeg -qt-libpng -qt-freetype -qt-zlib \
         -pkg-config -no-mtdev \
         -xkb-config-root /snap/qt-imx/current/usr/share/X11/xkb \
         -device ${DEVICE} ${DEVICE_OPTIONS} \
@@ -204,9 +203,11 @@ parts:
       - strace
       - gdb
     override-build: |
-      ${CRAFT_PROJECT_DIR}/stage/usr/bin/qmake
+      ${CRAFT_STAGE}/usr/bin/qmake
       make -j$(nproc)
       make INSTALL_ROOT=${CRAFT_PART_INSTALL} install
+    stage:
+      - -lib
 
 apps:
   hello-world:

--- a/qt-imx/snap/snapcraft.yaml
+++ b/qt-imx/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: itrue-qt-imx-snap
-base: core20
+base: core22
 version: '5.6.3'
 summary: Qt application libraries for i.MX 6 & 8 SoCs
 description: |
@@ -19,6 +19,11 @@ description: |
 grade: devel
 confinement: devmode
 
+platforms:
+  arm64:
+    build-on: [amd64]
+    build-for: [arm64]
+
 plugs:
   gpu:
     interface: custom-device
@@ -30,22 +35,16 @@ parts:
     build-packages:
       - wget
     override-pull: |
-      if [ "${SNAPCRAFT_TARGET_ARCH}" = "armhf" ]; then
-        export WGET_ARCH="aarch32"
-      elif [ "${SNAPCRAFT_TARGET_ARCH}" = "arm64" ]; then
-        export WGET_ARCH="aarch64"
-      else
-        echo "not supported!"
-        exit -1
-      fi
-      rm -f ${SNAPCRAFT_PART_SRC}/imx-gpu-viv.bin
+      # Hardcoded for arm64 cross-compilation
+      export WGET_ARCH="aarch64"
+      rm -f ${CRAFT_PART_SRC}/imx-gpu-viv.bin
       wget https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/imx-gpu-viv-6.4.3.p0.0-${WGET_ARCH}.bin \
-        -O ${SNAPCRAFT_PART_SRC}/imx-gpu-viv.bin
-      chmod a+x ${SNAPCRAFT_PART_SRC}/imx-gpu-viv.bin
-      ${SNAPCRAFT_PART_SRC}/imx-gpu-viv.bin --auto-accept --force
+        -O ${CRAFT_PART_SRC}/imx-gpu-viv.bin
+      chmod a+x ${CRAFT_PART_SRC}/imx-gpu-viv.bin
+      ${CRAFT_PART_SRC}/imx-gpu-viv.bin --auto-accept --force
     organize:
-      imx-gpu-viv-6.4.3.p0.0-aarch64/gpu-core/usr/lib/fb/*: usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/
-      imx-gpu-viv-6.4.3.p0.0-aarch64/gpu-core/usr/lib/*.so*: usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/
+      imx-gpu-viv-6.4.3.p0.0-aarch64/gpu-core/usr/lib/fb/*: usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/
+      imx-gpu-viv-6.4.3.p0.0-aarch64/gpu-core/usr/lib/*.so*: usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/
       imx-gpu-viv-6.4.3.p0.0-aarch64/gpu-core/usr/lib/pkgconfig: usr/lib/pkgconfig
       imx-gpu-viv-6.4.3.p0.0-aarch64/gpu-core/usr/lib/dri: usr/lib/dri
       imx-gpu-viv-6.4.3.p0.0-aarch64/gpu-core/usr/include: usr/include
@@ -76,10 +75,10 @@ parts:
       - libbsd0
       - libglvnd0
       - libdrm2
-      - libicu66
+      - libicu70
       - libcrypt1
       - libdbus-1-3
-      - libffi7
+      - libffi8
       - libglapi-mesa
       - libwayland-client0
       - libwayland-cursor0
@@ -102,28 +101,28 @@ parts:
       - libpcre3
       - libuuid1
       - libselinux1
-      - libsepol1
+      - libsepol2
       - libmount1
     override-build: |
-      snapcraftctl build
+      craftctl default
       # Move all files from /lib to /usr/lib and create a symlink
-      cp -r ${SNAPCRAFT_PART_INSTALL}/lib/* ${SNAPCRAFT_PART_INSTALL}/usr/lib/
-      rm -rf ${SNAPCRAFT_PART_INSTALL}/lib
-      ln -sr ${SNAPCRAFT_PART_INSTALL}/usr/lib ${SNAPCRAFT_PART_INSTALL}/lib
+      cp -r ${CRAFT_PART_INSTALL}/lib/* ${CRAFT_PART_INSTALL}/usr/lib/
+      rm -rf ${CRAFT_PART_INSTALL}/lib
+      ln -sr ${CRAFT_PART_INSTALL}/usr/lib ${CRAFT_PART_INSTALL}/lib
     stage:
       # Remove all mesa GL libraries
-      - -usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libGLES*
-      - -usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libGL.*
-      - -usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libEGL*
-      - -usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libGLX*
-      - -usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libvulkan*
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libGLES*
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libGL.*
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libEGL*
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libGLX*
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libvulkan*
       - -usr/include/EGL
       - -usr/include/GL
       - -usr/include/GLES*
       - -usr/include/KHR/khrplatform.h
     prime:
-      - -usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
-      - -usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libdrm_*
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libdrm_*
       - -usr/lib/udev
       - -usr/lib/cmake
       - -usr/share/doc
@@ -138,27 +137,20 @@ parts:
     source-depth: 1
     build-environment:
       - PATH: /usr/lib/ccache:${PATH}
-      - on amd64:
-        - DEVICE_OPTIONS: "-device-option CROSS_COMPILE=${SNAPCRAFT_ARCH_TRIPLET}-"
-        - to armhf:
-          - DEVICE: "linux-imx6-g++"
-        - to arm64:
-          - DEVICE: "linux-imx8-g++"
-      - on armhf:
-        - DEVICE_OPTIONS: ""
-        - DEVICE: "linux-imx6-g++"
-      - on arm64:
-        - DEVICE_OPTIONS: ""
-        - DEVICE: "linux-imx8-g++"
+      # Hardcoded for arm64 cross-compilation from amd64
+      - DEVICE_OPTIONS: "-device-option CROSS_COMPILE=aarch64-linux-gnu-"
+      - DEVICE: "linux-imx8-g++"
     build-packages:
       - patch
       - pkg-config
       - python-is-python3
+      - g++-aarch64-linux-gnu
+      - gcc-aarch64-linux-gnu
     override-pull: |
-      snapcraftctl pull
-      patch -p1 < ${SNAPCRAFT_PROJECT_DIR}/patches/0001-Added-linux-imx8-g.patch
-      patch -p1 < ${SNAPCRAFT_PROJECT_DIR}/patches/0002-Do-not-enforce-CROSS_COMPILE.patch
-      patch -p1 < ${SNAPCRAFT_PROJECT_DIR}/patches/0003-SocketCAN-Fix-compiler-error-SIOCGSTAMP-was-not-decl.patch
+      craftctl default
+      patch -p1 < ${CRAFT_PROJECT_DIR}/patches/0001-Added-linux-imx8-g.patch
+      patch -p1 < ${CRAFT_PROJECT_DIR}/patches/0002-Do-not-enforce-CROSS_COMPILE.patch
+      patch -p1 < ${CRAFT_PROJECT_DIR}/patches/0003-SocketCAN-Fix-compiler-error-SIOCGSTAMP-was-not-decl.patch
     override-build: |
       # Unset all snapcraft build variables so they don't interfere
       unset LD
@@ -170,16 +162,16 @@ parts:
       unset PKG_CONFIG_PATH
 
       ./configure -debug -nomake tests -nomake examples -opensource -confirm-license \
-        -prefix /usr -sysroot ${SNAPCRAFT_PROJECT_DIR}/stage \
+        -prefix /usr -sysroot ${CRAFT_PROJECT_DIR}/stage \
         -opengl es2 -no-pulseaudio -qpa eglfs -qt-xcb -qt-pcre \
         -qt-libjpeg -qt-libpng -qt-freetype -qt-zlib -qt-xkbcommon-x11 \
         -pkg-config -no-mtdev \
         -xkb-config-root /snap/qt-imx/current/usr/share/X11/xkb \
         -device ${DEVICE} ${DEVICE_OPTIONS} \
         -no-alsa -no-openssl -no-audio-backend -no-use-gold-linker \
-        -extprefix ${SNAPCRAFT_PART_INSTALL}/usr \
+        -extprefix ${CRAFT_PART_INSTALL}/usr \
         -skip qtwebengine \
-        -libdir ${SNAPCRAFT_PART_INSTALL}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/
+        -libdir ${CRAFT_PART_INSTALL}/usr/lib/aarch64-linux-gnu/
 
       make -j$(nproc)
 
@@ -194,10 +186,10 @@ parts:
       - qt5
     plugin: nil
     override-build: |
-      cat > ${SNAPCRAFT_PART_INSTALL}/qt.conf << EOF
+      cat > ${CRAFT_PART_INSTALL}/qt.conf << EOF
       [Paths]
       Prefix = ../
-      Libraries = ../lib/${SNAPCRAFT_ARCH_TRIPLET}/
+      Libraries = ../lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/
       Sysroot = ../../
       EOF
     organize:
@@ -212,9 +204,9 @@ parts:
       - strace
       - gdb
     override-build: |
-      ${SNAPCRAFT_PROJECT_DIR}/stage/usr/bin/qmake
+      ${CRAFT_PROJECT_DIR}/stage/usr/bin/qmake
       make -j$(nproc)
-      make INSTALL_ROOT=${SNAPCRAFT_PART_INSTALL} install
+      make INSTALL_ROOT=${CRAFT_PART_INSTALL} install
 
 apps:
   hello-world:
@@ -233,11 +225,17 @@ build-packages:
   - perl
   - python3
   - ccache
-  - on amd64:
-    - g++-${SNAPCRAFT_ARCH_TRIPLET}
-    - gcc-${SNAPCRAFT_ARCH_TRIPLET}
-    - binutils-${SNAPCRAFT_ARCH_TRIPLET}
-  - else:
+  - on amd64 to arm64:
+    - g++-aarch64-linux-gnu
+    - gcc-aarch64-linux-gnu
+    - binutils-aarch64-linux-gnu
+  - on amd64 to armhf:
+    - g++-arm-linux-gnueabihf
+    - gcc-arm-linux-gnueabihf
+    - binutils-arm-linux-gnueabihf
+  - on arm64:
+    - g++
+  - on armhf:
     - g++
 
 layout:
@@ -249,8 +247,8 @@ layout:
     bind: $SNAP/usr/share/fonts
   /usr/share/glvnd:
     bind: $SNAP/usr/share/glvnd
-  /usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri:
-    bind: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
+  /usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri:
+    bind: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri
   /usr/share/libdrm:
     bind: $SNAP/usr/share/libdrm
   /usr/lib/fonts:

--- a/qt-imx/snap/snapcraft.yaml
+++ b/qt-imx/snap/snapcraft.yaml
@@ -36,11 +36,11 @@ parts:
     override-pull: |
       # Hardcoded for arm64 cross-compilation
       export WGET_ARCH="aarch64"
-      rm -f ${CRAFT_PART_SRC}/imx-gpu-viv.bin
-      wget https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/imx-gpu-viv-6.4.3.p0.0-${WGET_ARCH}.bin \
-        -O ${CRAFT_PART_SRC}/imx-gpu-viv.bin
-      chmod a+x ${CRAFT_PART_SRC}/imx-gpu-viv.bin
-      ${CRAFT_PART_SRC}/imx-gpu-viv.bin --auto-accept --force
+      rm -f "${CRAFT_PART_SRC}/imx-gpu-viv.bin"
+      wget "https://www.nxp.com/lgfiles/NMG/MAD/YOCTO/imx-gpu-viv-6.4.3.p0.0-${WGET_ARCH}.bin" \
+        -O "${CRAFT_PART_SRC}/imx-gpu-viv.bin"
+      chmod a+x "${CRAFT_PART_SRC}/imx-gpu-viv.bin"
+      "${CRAFT_PART_SRC}/imx-gpu-viv.bin" --auto-accept --force
     organize:
       imx-gpu-viv-6.4.3.p0.0-aarch64/gpu-core/usr/lib/fb/*: usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/
       imx-gpu-viv-6.4.3.p0.0-aarch64/gpu-core/usr/lib/*.so*: usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/
@@ -105,9 +105,9 @@ parts:
     override-build: |
       craftctl default
       # Move all files from /lib to /usr/lib and create a symlink
-      cp -r ${CRAFT_PART_INSTALL}/lib/* ${CRAFT_PART_INSTALL}/usr/lib/
-      rm -rf ${CRAFT_PART_INSTALL}/lib
-      ln -sr ${CRAFT_PART_INSTALL}/usr/lib ${CRAFT_PART_INSTALL}/lib
+      cp -r "${CRAFT_PART_INSTALL}/lib/"* "${CRAFT_PART_INSTALL}/usr/lib/"
+      rm -rf "${CRAFT_PART_INSTALL}/lib"
+      ln -sr "${CRAFT_PART_INSTALL}/usr/lib" "${CRAFT_PART_INSTALL}/lib"
     stage:
       # Remove all mesa GL libraries
       - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libGLES*
@@ -147,9 +147,9 @@ parts:
       - gcc-aarch64-linux-gnu
     override-pull: |
       craftctl default
-      patch -p1 < ${CRAFT_PROJECT_DIR}/patches/0001-Added-linux-imx8-g.patch
-      patch -p1 < ${CRAFT_PROJECT_DIR}/patches/0002-Do-not-enforce-CROSS_COMPILE.patch
-      patch -p1 < ${CRAFT_PROJECT_DIR}/patches/0003-SocketCAN-Fix-compiler-error-SIOCGSTAMP-was-not-decl.patch
+      patch -p1 < "${CRAFT_PROJECT_DIR}/patches/0001-Added-linux-imx8-g.patch"
+      patch -p1 < "${CRAFT_PROJECT_DIR}/patches/0002-Do-not-enforce-CROSS_COMPILE.patch"
+      patch -p1 < "${CRAFT_PROJECT_DIR}/patches/0003-SocketCAN-Fix-compiler-error-SIOCGSTAMP-was-not-decl.patch"
     override-build: |
       # Unset all snapcraft build variables so they don't interfere
       unset LD
@@ -161,16 +161,16 @@ parts:
       unset PKG_CONFIG_PATH
 
       ./configure -debug -nomake tests -nomake examples -opensource -confirm-license \
-        -prefix /usr -sysroot ${CRAFT_STAGE} \
-        -opengl es2 -no-pulseaudio -qpa eglfs -no-xcb -qt-pcre \
+        -prefix /usr -sysroot "${CRAFT_STAGE}" \
+        -opengl es2 -no-pulseaudio -qpa eglfs -no-xcb -wayland -qt-pcre \
         -qt-libjpeg -qt-libpng -qt-freetype -qt-zlib \
         -pkg-config -no-mtdev \
         -xkb-config-root /snap/qt-imx/current/usr/share/X11/xkb \
-        -device ${DEVICE} ${DEVICE_OPTIONS} \
+        -device "${DEVICE}" ${DEVICE_OPTIONS} \
         -no-alsa -no-openssl -no-audio-backend -no-use-gold-linker \
-        -extprefix ${CRAFT_PART_INSTALL}/usr \
+        -extprefix "${CRAFT_PART_INSTALL}/usr" \
         -skip qtwebengine \
-        -libdir ${CRAFT_PART_INSTALL}/usr/lib/aarch64-linux-gnu/
+        -libdir "${CRAFT_PART_INSTALL}/usr/lib/aarch64-linux-gnu/"
 
       make -j$(nproc)
 
@@ -185,7 +185,7 @@ parts:
       - qt5
     plugin: nil
     override-build: |
-      cat > ${CRAFT_PART_INSTALL}/qt.conf << EOF
+      cat > "${CRAFT_PART_INSTALL}/qt.conf" << EOF
       [Paths]
       Prefix = ../
       Libraries = ../lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/
@@ -203,9 +203,9 @@ parts:
       - strace
       - gdb
     override-build: |
-      ${CRAFT_STAGE}/usr/bin/qmake
+      "${CRAFT_STAGE}/usr/bin/qmake"
       make -j$(nproc)
-      make INSTALL_ROOT=${CRAFT_PART_INSTALL} install
+      make INSTALL_ROOT="${CRAFT_PART_INSTALL}" install
     stage:
       - -lib
 


### PR DESCRIPTION
## Pull Request introduction


- [x] This PR fixes issue #9 
- [x] I have signed the [Canonical contributor license agreement](https://ubuntu.com/legal/contributors)
- [x] I have followed the [Style Guide](/README.md#Contributing)


## Pull Request description

This PR introduces the 22 branch for core22 (Ubuntu 22.04) support.                                                 
                                                                                                                      
### Branch Contents                                                                                                     
                                                                                                                      
- automount-actions: Auto-mount USB, sideload asserted snaps via snapd REST API                                     
- basic-server: TCP server on configurable port using ncat                                                          
- daemon-control: Cross-snap daemon orchestration via snapd-control interface                                       
- one-codebase-many-snaps: Multi-snap build from single repository using Makefile                                   
- qt-imx: Qt5 libraries for i.MX 6/8 SoCs with eglfs backend                                                        
- using-docker: Docker container orchestration on Ubuntu Core                                                       
                                                                                                                      
### Key Characteristics (core22)                                                                                        
                                                                                                                      
- base: core22                                                                                                      
- Uses CRAFT_* environment variables (CRAFT_PART_INSTALL, CRAFT_PROJECT_DIR, CRAFT_ARCH_TRIPLET_BUILD_FOR,          
  CRAFT_STAGE)                                                                                                        
- Uses craftctl default instead of snapcraftctl                                                                     
- Uses architectures key (list format)                                                                              
- Library versions: libicu70, libffi8, libsepol2                                                                    
                                                                                                                      
###  qt-imx Specific Fixes                                                                                               
                                                                                                                      
- Use ${CRAFT_STAGE} for sysroot path                                                                               
- Add OpenGL ES include/library paths to mkspec patch                                                               
- Disable XCB (-no-xcb) for embedded eglfs-only build                                                               
- Add stage: - -lib to hello-world part to fix staging conflicts                                                    
                                                                                                                      
This branch provides maintained versions of all example snaps for devices running Ubuntu Core 22.

## Pull Request elaboration

No new TODOs introduced. This branch contains all example snaps adapted for core22.

- [x] I have documented any new functions or features either in code or in the
  example's README
- [ ] I have added relevant tests or marked `TODO`s for what successful tests
  look like
